### PR TITLE
Make wget more robust and less noisy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ language: generic
 env:
 - JAVA_HOME=$HOME/jdk PATH=$JAVA_HOME/bin:$PATH GRAALVM_VERSION="20.1.0" GRAALVM_JAVA_VERSION="11"
 install:
-- wget -O $HOME/jdk.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java11-linux-amd64-20.1.0.tar.gz
+- travis_retry wget --no-verbose -O $HOME/jdk.tar.gz https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-20.1.0/graalvm-ce-java11-linux-amd64-20.1.0.tar.gz
 - mkdir $HOME/jdk && tar -xzf $HOME/jdk.tar.gz -C $HOME/jdk --strip-components=1
 - "$HOME/jdk/bin/gu install native-image"
 script:


### PR DESCRIPTION
This avoids [really long Travis log](https://travis-ci.org/github/yatta-lang/yatta/builds/691793966#L8856). IIRC, the limit for the Travis UI are 10k lines.