### PR TITLE
Avoid timeout errors on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - mkdir $HOME/jdk && tar -xzf $HOME/jdk.tar.gz -C $HOME/jdk --strip-components=1
 - "$HOME/jdk/bin/gu install native-image"
 script:
-- mvn package -B
+- travis_wait 30 mvn package -B
 notifications:
   webhooks:
     urls:


### PR DESCRIPTION
See https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received